### PR TITLE
[#113205395] Cases are not appearing under the CC's "visits" tab on Banyan dashboard (from Zendesk #9673)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,7 +3,7 @@
 
 == ruote - 2.3.2    not yet released
 
-- Add '_grd' type to HashStorage
+- Add 'guard' type to HashStorage
 
 == ruote - 2.3.1    released 2013/05/05
 

--- a/lib/ruote/storage/hash_storage.rb
+++ b/lib/ruote/storage/hash_storage.rb
@@ -197,7 +197,7 @@ module Ruote
         configurations
         workitems
 
-        _grd
+        guard
 
       ].each_with_object({}) { |k, h|
         h[k] = {}


### PR DESCRIPTION
**Feature [#113205395]:**
- Added `guard` as new cache type in HashStorage. 
- Updated min version: `2.3.2`
- Tracker: [#113205395](https://www.pivotaltracker.com/story/show/113205395)